### PR TITLE
drivers: net: pfe_eth: minor fix buf_desc

### DIFF
--- a/include/pfe_eth/pfe_driver.h
+++ b/include/pfe_eth/pfe_driver.h
@@ -28,10 +28,10 @@ struct __packed hif_header_s {
 };
 
 struct __packed buf_desc {
-	u32 ctrl;
-	u32 status;
-	u32 data;
-	u32 next;
+	volatile u32 ctrl;
+	volatile u32 status;
+	volatile u32 data;
+	volatile u32 next;
 };
 
 struct rx_desc_s {


### PR DESCRIPTION
The definition of struct buf_desc is missing volatile, may cause the description is incorrect.